### PR TITLE
Populate LightRAG README and remove PathRAG

### DIFF
--- a/memory/storage/.gitkeep
+++ b/memory/storage/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It's used to ensure Git tracks the 'memory/storage' directory.

--- a/memory/storage/README.md
+++ b/memory/storage/README.md
@@ -1,0 +1,19 @@
+# Augmented Storage Types
+
+This directory contains information on various augmented storage types, specifically focusing on different Retrieval Augmented Generation (RAG) implementations.
+
+## RAG Implementations
+
+- [Standard RAG](./standard_rag.md)
+- [GraphRAG](./graph_rag.md)
+- [LightRAG](./light_rag.md)
+
+Each file provides details on the specific RAG implementation, including:
+
+- Description
+- Relevant Studies
+- Providers
+- Pros
+- Cons
+
+Please refer to the individual files for more information.

--- a/memory/storage/graph_rag.md
+++ b/memory/storage/graph_rag.md
@@ -1,0 +1,40 @@
+# GraphRAG
+
+## Description
+GraphRAG is a graph-based approach to Retrieval-Augmented Generation designed to enhance question answering over private text corpora. It particularly aims to address "global" questions that require understanding and summarizing an entire body of text, rather than just retrieving specific facts. GraphRAG combines the strengths of traditional RAG with query-focused summarization (QFS).
+
+The core methodology involves using a Large Language Model (LLM) to construct a structured graph index of the source documents. This process typically occurs in two main stages:
+1.  **Entity Knowledge Graph Creation:** An LLM processes the source documents to identify key entities and their relationships, building an entity knowledge graph. This graph represents the interconnected concepts and information within the text.
+2.  **Community Summary Pre-generation:** Based on the entity knowledge graph, the system identifies clusters or "communities" of closely related entities. Summaries for these communities are then pre-generated, capturing the essence of themes or topics within those clusters.
+
+When a user poses a question:
+1.  The system utilizes the pre-generated community summaries relevant to the query to form partial responses.
+2.  These partial responses, drawn from different parts of the knowledge graph, are then synthesized and summarized by an LLM into a final, comprehensive answer.
+
+## Studies
+A key piece of research introducing and evaluating GraphRAG is:
+- **Title:** "From Local to Global: A Graph RAG Approach to Query-Focused Summarization"
+- **Authors:** Darren Edge, Ha Trinh, Newman Cheng, Joshua Bradley, Alex Chao, Apurva Mody, Steven Truitt, Dasha Metropolitansky, Robert Osazuwa Ness, Jonathan Larson
+- **Reference:** [arXiv:2404.16130 [cs.CL]](https://arxiv.org/abs/2404.16130) (Submitted on April 24, 2024)
+- **Findings:** The paper demonstrates that for global sensemaking questions (e.g., identifying main themes) over datasets around 1 million tokens, GraphRAG significantly improves the comprehensiveness and diversity of answers compared to conventional RAG baselines.
+
+## Providers
+GraphRAG is a concept heavily researched and developed by Microsoft.
+- **Microsoft:** Given the authorship of the foundational paper and ongoing research in this area, Microsoft (likely through Azure AI services and Microsoft Research) is a primary driver and potential provider of GraphRAG technology and tools.
+- Other AI-focused companies and graph database providers may also explore or integrate GraphRAG principles as the methodology matures.
+
+## Pros
+- **Improved Handling of Global Queries:** Effectively answers broad, thematic questions about an entire document collection, where standard RAG might struggle.
+- **Enhanced Comprehensiveness & Diversity:** Generates answers that are more complete and cover a wider range of relevant information, especially for complex queries.
+- **Scalability for Summarization:** Designed to scale with the generality of user questions and the overall size of the text corpus for summarization tasks.
+- **Structured Knowledge Utilization:** Leverages a knowledge graph, enabling a more nuanced understanding of relationships and contexts within the data.
+- **Combines RAG and QFS Strengths:** Integrates the fact-specific retrieval capabilities of RAG with the summarization power of QFS.
+- **Pre-computation of Summaries:** Community summaries can be pre-generated, potentially speeding up response times for certain types of queries.
+
+## Cons
+- **Complexity of Indexing:** The multi-stage process of building an entity knowledge graph and then pre-generating community summaries using LLMs can be more complex and computationally intensive than typical RAG indexing.
+- **Quality Dependency on Graph Construction:** The accuracy and usefulness of GraphRAG heavily depend on the quality of the LLM-generated knowledge graph and community summaries. Biases or errors in graph construction can impact results.
+- **Upfront Processing Overhead:** Significant computational resources and time may be required for the initial graph creation and summary generation, especially for very large datasets.
+- **Novelty and Maturity:** As a relatively new approach (highlighted by the 2024 paper), best practices, standardized tools, and widespread industry adoption are still evolving.
+- **Scalability Challenges for Dynamic Data:** While designed for scalability, maintaining the graph index and community summaries for highly dynamic or rapidly changing datasets could pose ongoing challenges.
+- **Potential for Over-Summarization:** If not carefully tuned, the process of summarizing summaries could lead to loss of important details or nuances.

--- a/memory/storage/light_rag.md
+++ b/memory/storage/light_rag.md
@@ -1,0 +1,45 @@
+# LightRAG
+
+## Description
+LightRAG is an open-source Python library designed to facilitate "Simple and Fast Retrieval-Augmented Generation." It provides a comprehensive framework for building RAG applications by offering tools and modules for various stages of the RAG pipeline. This includes document ingestion and parsing (with multimodal capabilities through MinerU integration), chunking, embedding generation, knowledge graph creation and manipulation, diverse storage backend options, flexible LLM and embedding model integration, and multiple retrieval strategies.
+
+LightRAG aims for both ease of use for developers and high performance. It comes with a Web UI for interactive tasks like document indexing, knowledge graph exploration, and querying, as well as an API (including an Ollama-compatible interface) for programmatic access.
+
+Key functionalities highlighted in its documentation include:
+- Support for various storage solutions (JSON, PostgreSQL, Neo4j, FAISS, Milvus, Chroma, Qdrant, etc.).
+- Compatibility with multiple LLM providers and local models (OpenAI, Hugging Face, Ollama, LlamaIndex).
+- Different query modes: `local`, `global`, `hybrid`, `naive`, `mix`, `bypass`.
+- Knowledge graph features: creation, visualization, editing entities/relations, custom KG import, entity merging.
+- Multimodal document processing for formats like PDFs, images, and Office documents, extracting text, images, tables, and formulas.
+- Utilities such as conversation history management, token usage tracking, data export, and caching mechanisms.
+
+## Studies and Evaluation
+LightRAG is an active research project and framework. Its development and performance are documented in:
+- **Primary Paper:** "LightRAG: Simple and Fast Retrieval-Augmented Generation" by Zirui Guo, Lianghao Xia, Yanhua Yu, Tu Ao, Chao Huang. (Available on arXiv: [2410.05779 [cs.IR]](https://arxiv.org/abs/2410.05779)).
+- **Evaluation:** The project includes resources for evaluating RAG systems, utilizing datasets like "TommyChien/UltraDomain" from Hugging Face. It provides prompts and methodologies for assessing answers based on criteria such as Comprehensiveness, Diversity, and Empowerment. The GitHub repository also presents performance comparison tables against other RAG approaches like NaiveRAG, RQ-RAG, HyDE, and GraphRAG across different domains.
+
+## Developers/Providers
+- LightRAG is developed and maintained by the contributors to the [HKUDS/LightRAG GitHub repository](https://github.com/HKUDS/LightRAG). HKUDS likely refers to a research group or department at The University of Hong Kong (e.g., Department of Statistics and Actuarial Science).
+- As an open-source project under the MIT License, it is freely available for use and modification. Commercial support or services would typically come from third parties building solutions on top of LightRAG rather than the core developers directly.
+
+## Pros
+- **Comprehensive & Integrated:** Offers a wide array of tools covering most aspects of the RAG pipeline within a single library.
+- **Ease of Use & Speed:** Designed with simplicity and performance as key goals.
+- **Flexibility:** Highly configurable with support for numerous LLMs, embedding models, and storage backends.
+- **Advanced KG Capabilities:** Strong support for knowledge graph creation, manipulation, and querying, which can lead to more sophisticated RAG applications.
+- **Multimodal Data Handling:** Integration with MinerU allows processing of complex documents containing text, images, tables, and formulas.
+- **User Interface & API:** Provides both a Web UI for easier interaction and management, and robust APIs for integration into other systems.
+- **Open Source (MIT License):** Allows for broad adoption, customization, and community contributions.
+- **Active Development:** The project shows continuous improvements and feature additions.
+- **Built-in Evaluation:** Includes tools and benchmarks for assessing the performance of RAG applications built with it.
+- **Rich Feature Set:** Includes conversation history, citation support, token tracking, cache management, and various data export options.
+
+## Cons & Challenges
+- **Initialization Complexity:** Requires careful initialization of storage and pipeline components; errors in this stage are common for new users.
+- **Dependency Management:** The extensive list of supported integrations can mean a complex set of dependencies for users to install and manage, tailored to their specific configuration.
+- **Configuration Overhead:** While flexible, the numerous options for models, storage, and query parameters can present a steep learning curve.
+- **Resource Intensive:** Despite "Light" in its name, deploying a full RAG system with sophisticated models and large datasets can still demand significant computational resources (CPU, memory, GPU).
+- **Data Handling with Model Switching:** Users must clear data directories when changing embedding models to prevent errors, which could be inconvenient.
+- **Maturity of All Components:** As a rapidly evolving project, some newer features or less common configurations might be less battle-tested.
+- **External System Dependencies:** Leveraging certain features (like specific databases or MinerU for full multimodal capabilities) requires setting up and maintaining those external systems.
+- **Potential for Known Issues:** As with any complex software, there can be known issues with specific versions or integrations (e.g., the Apache AGE issue mentioned in its documentation).

--- a/memory/storage/standard_rag.md
+++ b/memory/storage/standard_rag.md
@@ -1,0 +1,36 @@
+# Standard RAG
+
+## Description
+Retrieval-Augmented Generation (RAG) is an AI framework for retrieving facts from an external knowledge base to ground large language models (LLMs) on the most accurate, up-to-date information and to give users insight into LLMs' generative process.
+It involves two main phases:
+1.  **Retrieval:** Algorithms search for and retrieve snippets of information relevant to the user’s prompt or question. In an open-domain, consumer setting, these facts can come from indexed documents on the internet. In a closed-domain, enterprise setting, a narrower set of sources are typically used for added security and reliability.
+2.  **Content Generation:** This assortment of external knowledge is appended to the user’s prompt and passed to the language model. The LLM then draws from the augmented prompt and its internal representation of its training data to synthesize an engaging answer tailored to the user.
+
+## Studies
+The concept of RAG was introduced in a 2020 paper by Meta (then Facebook) to give LLMs access to information beyond their training data.
+- Meta, 2020: [Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks](https://arxiv.org/abs/2005.11401v4)
+
+## Providers
+Many cloud providers and AI companies offer RAG capabilities as part of their LLM platforms and services. Some prominent examples include:
+- IBM (e.g., watsonx.ai)
+- Amazon Web Services (AWS)
+- Google Cloud (Vertex AI)
+- Microsoft Azure (Azure AI Search)
+- Various other specialized LLM and vector database providers.
+
+## Pros
+- **Access to Current Information:** Ensures the model utilizes the most up-to-date and reliable facts.
+- **Verifiability:** Allows users to check the model's sources, enhancing trust and accuracy.
+- **Reduced Hallucinations:** Grounding on external, verifiable facts minimizes the chances of the LLM generating incorrect or misleading information.
+- **Reduced Need for Retraining:** Lessens the frequency and necessity of retraining the model with new data, as knowledge can be updated externally.
+- **Cost-Effective:** Can lower computational and financial costs associated with running LLM applications, especially in enterprise settings.
+- **Personalization:** Enables LLMs to provide more personalized responses without requiring extensive manual scripting for different scenarios.
+- **Dynamic Knowledge Updates:** New information (e.g., updated policies, documents) can be made available to the model by simply updating the external knowledge source.
+
+## Cons
+- **Imperfect Process:** RAG is not a flawless solution, and challenges exist in optimizing its components.
+- **Retrieval Quality Dependent:** The overall effectiveness heavily relies on the ability to find and fetch the most relevant information for the given prompt. Irrelevant or poorly ranked retrieved documents can lead to suboptimal responses.
+- **Generation Quality Dependent:** The way retrieved information is structured and presented to the LLM can significantly impact the quality of the generated response.
+- **Handling Unanswerable Questions:** LLMs need to be effectively trained or designed to recognize when they cannot answer a question based on the retrieved context, to avoid generating speculative or incorrect answers.
+- **Complexity in Fine-Tuning:** Training models to identify unanswerable questions or to ask clarifying questions can require substantial effort and data.
+- **Knowledge Gaps:** If the external knowledge source itself is incomplete or contains errors, the RAG system will inherit these limitations.


### PR DESCRIPTION
This commit includes the following updates:
- Gathered detailed information for LightRAG from the HKUDS/LightRAG GitHub repository.
- Populated `memory/storage/light_rag.md` with the description, studies, developers/providers, pros, and cons for LightRAG.
- Removed the placeholder file `memory/storage/path_rag.md` as per your request.
- Updated `memory/storage/README.md` to remove the link to the removed PathRAG file.

The READMEs for Standard RAG and GraphRAG were populated in a previous commit.